### PR TITLE
Fix pagination

### DIFF
--- a/src/SirvS3Client.php
+++ b/src/SirvS3Client.php
@@ -289,7 +289,7 @@ class SirvS3Client
                 ];
             }
 
-            $marker = (string) $xml->Marker;
+            $marker = (string) $xml->NextMarker;
         }
         while((string) $xml->IsTruncated == 'true' && is_null($max_keys));
 


### PR DESCRIPTION
Change name of the xml property to NextMarker, Marker is (in my case) an empty tag so it creates an infinite request loop when fetching a bucket with more than 1000 items.